### PR TITLE
formatting

### DIFF
--- a/quarto/precalc/vectors.qmd
+++ b/quarto/precalc/vectors.qmd
@@ -410,13 +410,11 @@ The last value of a vector is usually denoted by $v_n$. In `Julia`, the `length`
 There is [much more](http://julia.readthedocs.org/en/latest/manual/arrays/#indexing) to indexing than just indexing by a single integer value. For example, the following can be used for indexing:
 
   * a scalar integer (as seen)
-
-:::
-
   * a range
   * a vector of integers
   * a boolean vector
 
+:::
 
 Some add-on packages extend this further.
 
@@ -541,7 +539,7 @@ sum(v), length(v)
 Other desired operations with vectors act differently. Rather than reduce a collection of values using some formula, the goal is to apply some formula to *each* of the values, returning a modified vector. A simple example might be to square each element, or subtract the average value from each element. An example comes from statistics. When computing a variance, we start with data $x_1, x_2, \dots, x_n$ and along the way form the values $(x_1-\bar{x})^2, (x_2-\bar{x})^2, \dots, (x_n-\bar{x})^2$.
 
 
-Such things can be done in *many* differents ways. Here we describe two, but will primarily utilize the first.
+Such things can be done in *many* different ways. Here we describe two, but will primarily utilize the first.
 
 
 ### Broadcasting a function call
@@ -678,7 +676,7 @@ The first task is to create the data. We will soon see more convenient ways to g
 
 
 ```{julia}
-a,b, n = -1, 1, 7
+a, b, n = -1, 1, 7
 d = (b-a) // (n-1)
 𝐱s = [a, a+d, a+2d, a+3d, a+4d, a+5d, a+6d]  # 7 points
 ```
@@ -712,7 +710,7 @@ The style generally employed here is to use plural variable names for a collecti
 ## Other container types
 
 
-Vectors in `Julia` are a container, one of many different types. Another useful type for programming purposes are *tuples*. If a vector is formed by placing comma-separated values within a `[]` pair (e.g., `[1,2,3]`), a tuple is formed by placing comma-separated values withing a `()` pair. A tuple of length $1$ uses a convention of a trailing comma to distinguish it from a parethesized expression (e.g. `(1,)` is a tuple, `(1)` is just the value `1`).
+Vectors in `Julia` are a container, one of many different types. Another useful type for programming purposes are *tuples*. If a vector is formed by placing comma-separated values within a `[]` pair (e.g., `[1,2,3]`), a tuple is formed by placing comma-separated values withing a `()` pair. A tuple of length $1$ uses a convention of a trailing comma to distinguish it from a parenthesized expression (e.g. `(1,)` is a tuple, `(1)` is just the value `1`).
 
 
 Tuples are used in programming, as they don't typically require allocated memory to be used so they can be faster. Internal usages are for function arguments and function return types. Unlike vectors, tuples can be heterogeneous collections. (When commas are used to combine more than one output into a cell, a tuple is being used.) (Also, a big technical distinction is that tuples are also different from vectors and other containers in that tuple types are *covariant* in their parameters, not *invariant*.)


### PR DESCRIPTION
The description of tuples on line 713 of vectors.qmd isn't strictly correct. You can create a tuple without the parentheses if there is more than one value in the tuple. i.e.
```julia
a = 1, 2  # Creates a Tuple{Int64, Int64}
b = 1,  # Syntax error. Parentheses needed to be parsed correctly. -- b = (1,).
```
