### PR TITLE
rm WeaveSupport

### DIFF
--- a/quarto/ODEs/differential_equations.qmd
+++ b/quarto/ODEs/differential_equations.qmd
@@ -12,19 +12,6 @@ using Plots
 using ModelingToolkit
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "The `DifferentialEquations` suite",
-        description = "Calculus with Julia: The `DifferentialEquations` suite",
-        tags = ["CalculusWithJulia", "odes", "the `differentialequations` suite"],
-);
-fig_size = (800, 600)
-nothing
-```
 
 ---
 
@@ -428,5 +415,3 @@ plot(t -> sol(t)[3], t -> sol(t)[4], TSPAN..., legend=false)
 ```
 
 The toolkit will automatically generate fast functions and can perform transformations (such as is done by `ode_order_lowering`) before passing along to the numeric solves.
-
-

--- a/quarto/ODEs/euler.qmd
+++ b/quarto/ODEs/euler.qmd
@@ -13,20 +13,6 @@ using SymPy
 using Roots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-
-const frontmatter = (
-        title = "Euler's method",
-        description = "Calculus with Julia: Euler's method",
-        tags = ["CalculusWithJulia", "odes", "euler's method"],
-);
-fig_size = (800, 600)
-nothing
-```
 
 ---
 
@@ -816,4 +802,3 @@ choices = [
 answ = 4
 radioq(choices, answ, keep_order=true)
 ```
-

--- a/quarto/ODEs/odes.qmd
+++ b/quarto/ODEs/odes.qmd
@@ -12,18 +12,6 @@ using Plots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "ODEs",
-        description = "Calculus with Julia: ODEs",
-        tags = ["CalculusWithJulia", "odes", "odes"],
-);
-nothing
-```
 
 ---
 
@@ -982,4 +970,3 @@ choices = [
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/ODEs/solve.qmd
+++ b/quarto/ODEs/solve.qmd
@@ -11,19 +11,6 @@ using Plots
 using MonteCarloMeasurements
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "The problem-algorithm-solve interface",
-        description = "Calculus with Julia: The problem-algorithm-solve interface",
-        tags = ["CalculusWithJulia", "odes", "the problem-algorithm-solve interface"],
-);
-fig_size = (800, 600)
-nothing
-```
 
 ---
 
@@ -265,5 +252,3 @@ The only change was in the problem, `Problem(y0 = 0.0 ± 0.0, v0 = 30.0 ± 1.0)`
 
 
 This example, shows the flexibility of the problem-algorithm-solver pattern while maintaining a consistent pattern for execution.
-
-

--- a/quarto/README-quarto.md
+++ b/quarto/README-quarto.md
@@ -75,10 +75,12 @@ Then one should:
 ---
 Eventually, if this workflow seems to be settled:
 
-* move to not use CalculusWithJulia.WeaveSupport
-* deprecate need to make "pluto friendly"
+	* deprecate need to make "pluto friendly"
 * take advantage of mermaid, ojs, bibliography, ...
 
+DONE * move to not use CalculusWithJulia.WeaveSupport
+DONE * remove frontmatter
+DONE * fig_size -> _common_code
 DONE * deprecate .jmd files
 DONE? * do something with JSXGraph
 DONE * figure out why PlotlyLight doesn't work XXX hacky!

--- a/quarto/_common_code.qmd
+++ b/quarto/_common_code.qmd
@@ -1,6 +1,20 @@
 ```{julia}
 #| echo: false
 
+## Formatting options are included here; not in CalculusWithJulia.WeaveSupport
+using QuizQuestions
+nothing
+```
+
+```{julia}
+#| echo: false
+fig_size=(800, 600)
+nothing
+```
+
+```{julia}
+#| echo: false
+
 import Logging
 Logging.disable_logging(Logging.Info) # or e.g. Logging.Info
 Logging.disable_logging(Logging.Warn)
@@ -14,14 +28,165 @@ function Base.show(io::IO, ::MIME"text/html", x::T) where {T <: SymPy.SymbolicOb
     println(io, "</span>")
 end
 
-# hack to work around issue
+```
+
+```{julia}
+#| echo: false
+# ImageFile
+## WeaveSupport from CalculusWithJulia package
+## moved here to lighten up CwJ package
+import Base64: base64encode
 import Markdown
-import CalculusWithJulia
-function CalculusWithJulia.WeaveSupport.ImageFile(d::Symbol, f::AbstractString, caption; kwargs...)
-    nm = joinpath("..", string(d), f)
-    u = "![$caption]($nm)"
-    Markdown.parse(u)
+using Mustache
+using Tables
+
+# q and L
+using LaTeXStrings
+macro q_str(x)
+    "`$x`"
 end
 
-nothing
+"""
+
+Take an image file and encode it
+
+## Examples
+
+ImageFile("http://...", "caption")
+ImageFile("/fullpath/to_file/", "caption")
+ImageFile(:integrals, "figures/pic.png", "caption")
+ImageFile(p, "caption") # p a Plot object
+
+
+
+"""
+mutable struct ImageFile
+    f
+    caption
+    alt
+    width
+    content
+end
+# 2 args f, caption
+ImageFile(f,caption=""; alt="A Figure", width=nothing) = ImageFile(f, caption, alt, width)
+
+# 3 args dir, f, caption
+function ImageFile(dir::Symbol, f::AbstractString, caption;
+                   alt="A Figure", width=nothing)
+
+
+    basedir = replace(dirname(@__DIR__), "/src" => "")
+    #fname = joinpath(basedir, "CwJ", string(dir), f)
+    fname = joinpath(basedir, string(dir), f)
+
+    ImageFile(fname, caption, alt, width)
+end
+# plot -> string for file
+function ImageFile(f, caption, alt, width)
+    imgfile = tempname() * ".gif"
+    io = open(imgfile, "w")
+    show(io, "image/png", f)
+    close(io)
+    ImageFile(imgfile, caption, alt, width)
+end
+
+gif_to_img_tpl = Mustache.mt"""
+  <img src="data:image/gif;base64,{{{:data}}}" class="card-img-top" alt="{{{:alt}}}">
+"""
+
+function ImageFile(f::AbstractString, caption, alt, width)
+    fcontent = occursin(r"^http", f) ? read(download(f), String) : read(f, String)
+    data = base64encode(fcontent)
+    content = Mustache.render(gif_to_img_tpl, data=data, alt=alt)
+    caption = Markdown.parse(caption)
+    ImageFile(f, caption, alt, width, content)
+end
+
+function Base.show(io::IO, m::MIME"text/html", x::ImageFile)
+    content = x.content
+    if content == nothing
+        data = (read(x.f, String))
+        content = gif_to_image(data=data, alt="figure")
+    end
+    caption = sprint(io -> show(io, "text/html", x.caption))
+
+    print(io, """<div class="d-flex justify-content-center">""")
+    print(io, "  <figure>")
+    print(io, content)
+    print(io, "    <figcaption>")
+    print(io, caption)
+    print(io, """
+    </figcaption>
+  </figure>
+</div>
+""")
+end
+
+# hack to work around issue
+# import Markdown
+# import CalculusWithJulia
+# function CalculusWithJulia.WeaveSupport.ImageFile(d::Symbol, f::AbstractString, caption; kwargs...)
+#     nm = joinpath("..", string(d), f)
+#     u = "![$caption]($nm)"
+#     Markdown.parse(u)
+# end
+
+
+
+# Table
+#| echo: false
+#https://github.com/TheRoniOne/MDTable.jl/blob/master/src/write.jl
+function MDTable(io::IO, df)
+    rows = Tables.rows(df)
+    sch = Tables.schema(rows)
+    names = Tables.columnnames(rows)
+    header = true
+
+    headers::String = ""
+    for i in 1:length(names)
+        if i != length(names)
+            headers = headers * "| $(names[i]) "
+        else
+            headers = headers * "| $(names[i]) " * "|\n"
+        end
+    end
+    print(io, headers)
+
+    println(io, "| --- " ^ length(names) * "|")
+    for row in rows
+        line::String = ""
+        Tables.eachcolumn(sch, row) do val, i, nm
+            print(io, "| ", chomp(string(val)))
+        end
+        println(io, "|")
+    end
+end
+Table(d) = Markdown.parse(sprint(io -> MDTable(io, d)))
+table(d) = Table(d)
+
+# HTMLoutput
+struct HTMLoutput
+    x
+    centered::Bool
+    caption::String
+    HTMLoutput(x; centered::Bool=false, caption::String="") = new(x, centered, caption)
+end
+function Base.show(io::IO, ::MIME"text/html", x::HTMLoutput)
+    if !x.centered
+        txt = x.x
+    else
+        centered_content_tpl = """
+<div class="d-flex justify-content-center">
+<div class="card border-light mx-3 px-3 my-3 py-3" style="{{#:width}}width={{:width}}px{{/:width}}{{^:width}} max-width: 560px;{{/:width}}">
+  {{{:content}}}
+  <div class="card-footer text-muted">
+      {{{:caption}}}
+  </div>
+</div>
+</div>
+"""
+        txt = Mustache.render(centered_content_tpl; content=x.x, caption=x.caption)
+    end
+    print(io, txt)
+end
 ```

--- a/quarto/_quarto.yml
+++ b/quarto/_quarto.yml
@@ -1,4 +1,4 @@
-version: 0.10
+version: "0.11"
 
 project:
   type: book

--- a/quarto/derivatives/curve_sketching.qmd
+++ b/quarto/derivatives/curve_sketching.qmd
@@ -14,19 +14,6 @@ using Roots
 using Polynomials # some name clash with SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-fig_size=(800, 600)
-const frontmatter = (
-        title = "Curve Sketching",
-        description = "Calculus with Julia: Curve Sketching",
-        tags = ["CalculusWithJulia", "derivatives", "curve sketching"],
-);
-nothing
-```
 
 ---
 
@@ -611,4 +598,3 @@ choices = [
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/derivatives/derivatives.qmd
+++ b/quarto/derivatives/derivatives.qmd
@@ -15,17 +15,7 @@ using SymPy
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using DataFrames
-
-const frontmatter = (
-        title = "Derivatives",
-        description = "Calculus with Julia: Derivatives",
-        tags = ["CalculusWithJulia", "derivatives", "derivatives"],
-);
-
-fig_size=(800, 600)
-
 nothing
 ```
 
@@ -1645,4 +1635,3 @@ The limit of a composition (under assumptions on ``v``):
 ]
 radioq(choices, 3, keep_order=true)
 ```
-

--- a/quarto/derivatives/first_second_derivatives.qmd
+++ b/quarto/derivatives/first_second_derivatives.qmd
@@ -13,19 +13,6 @@ using SymPy
 using Roots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "The first and second derivatives",
-        description = "Calculus with Julia: The first and second derivatives",
-        tags = ["CalculusWithJulia", "derivatives", "the first and second derivatives"],
-);
-
-nothing
-```
 
 ---
 
@@ -1048,4 +1035,3 @@ choices = ["As ``x^3`` has no extrema at ``x=0``, neither will ``f``",
            "As ``x^4`` is of higher degree than ``x^3``, ``f`` will be ``U``-shaped, as ``x^4`` is."]
 radioq(choices, 1)
 ```
-

--- a/quarto/derivatives/implicit_differentiation.qmd
+++ b/quarto/derivatives/implicit_differentiation.qmd
@@ -13,18 +13,6 @@ using Roots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Implicit Differentiation",
-        description = "Calculus with Julia: Implicit Differentiation",
-        tags = ["CalculusWithJulia", "derivatives", "implicit differentiation"],
-);
-nothing
-```
 
 ---
 

--- a/quarto/derivatives/lhospitals_rule.qmd
+++ b/quarto/derivatives/lhospitals_rule.qmd
@@ -13,21 +13,6 @@ using SymPy
 
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-using Roots
-
-fig_size=(800, 600)
-const frontmatter = (
-        title = "L'Hospital's Rule",
-        description = "Calculus with Julia: L'Hospital's Rule",
-        tags = ["CalculusWithJulia", "derivatives", "l'hospital's rule"],
-);
-
-nothing
-```
 
 ---
 
@@ -259,6 +244,7 @@ A first proof of L'Hospital's rule takes advantage of Cauchy's [generalization](
 ```{julia}
 #| echo: false
 #| cache: true
+using Roots
 let
 ## {{{lhopitals_picture}}}
 
@@ -836,4 +822,3 @@ choices = [
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/derivatives/linearization.qmd
+++ b/quarto/derivatives/linearization.qmd
@@ -14,19 +14,6 @@ using TaylorSeries
 using DualNumbers
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Linearization",
-        description = "Calculus with Julia: Linearization",
-        tags = ["CalculusWithJulia", "derivatives", "linearization"],
-);
-
-nothing
-```
 
 ---
 
@@ -861,4 +848,3 @@ n=100
 val = exp(-n*(n-1)/2/365)
 numericq(val, 1e-2)
 ```
-

--- a/quarto/derivatives/mean_value_theorem.qmd
+++ b/quarto/derivatives/mean_value_theorem.qmd
@@ -16,18 +16,8 @@ using Roots
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using Printf
 using SymPy
-
-fig_size = (800, 600)
-
-const frontmatter = (
-        title = "The mean value theorem for differentiable functions.",
-        description = "Calculus with Julia: The mean value theorem for differentiable functions.",
-        tags = ["CalculusWithJulia", "derivatives", "the mean value theorem for differentiable functions."],
-);
-
 nothing
 ```
 
@@ -707,4 +697,3 @@ L"The squeeze theorem applies, as $0 < g(x) < x$",
 answ = 3
 radioq(choices, answ)
 ```
-

--- a/quarto/derivatives/more_zeros.qmd
+++ b/quarto/derivatives/more_zeros.qmd
@@ -14,19 +14,6 @@ using Roots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-const frontmatter = (
-        title = "Derivative-free alternatives to Newton's method",
-        description = "Calculus with Julia: Derivative-free alternatives to Newton's method",
-        tags = ["CalculusWithJulia", "derivatives", "derivative-free alternatives to newton's method"],
-);
-
-nothing
-```
-
 ---
 
 
@@ -614,4 +601,3 @@ choices = [
 answ = 3
 radioq(choices, answ, keep_order=true)
 ```
-

--- a/quarto/derivatives/newtons_method.qmd
+++ b/quarto/derivatives/newtons_method.qmd
@@ -13,20 +13,6 @@ using SymPy
 using Roots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-fig_size = (800, 600)
-const frontmatter = (
-        title = "Newton's method",
-        description = "Calculus with Julia: Newton's method",
-        tags = ["CalculusWithJulia", "derivatives", "newton's method"],
-);
-
-nothing
-```
 
 ---
 

--- a/quarto/derivatives/numeric_derivatives.qmd
+++ b/quarto/derivatives/numeric_derivatives.qmd
@@ -14,18 +14,6 @@ using SymPy
 using Roots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Numeric derivatives",
-        description = "Calculus with Julia: Numeric derivatives",
-        tags = ["CalculusWithJulia", "derivatives", "numeric derivatives"],
-);
-nothing
-```
 
 ---
 
@@ -383,4 +371,3 @@ fp_(h) = 3*32h^2 - 62
 c = 2
 numericq(fp_(2))
 ```
-

--- a/quarto/derivatives/optimization.qmd
+++ b/quarto/derivatives/optimization.qmd
@@ -13,20 +13,6 @@ using Roots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-fig_size = (800, 600)
-frontmatter = (
-    title = "Optimization",
-    description = "Calculus with Julia: Optimization",
-    tags = ["CalculusWithJulia", "derivatives", "optimization"],
-);
-
-nothing
-```
 
 ---
 
@@ -1478,4 +1464,3 @@ d(a) = (a-x(a))^2 + (a^2 - x(a)^2)^2
 a = find_zero(d', 1)
 numericq(a)
 ```
-

--- a/quarto/derivatives/related_rates.qmd
+++ b/quarto/derivatives/related_rates.qmd
@@ -13,19 +13,6 @@ using Roots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-fig_size=(800, 600)
-const frontmatter = (
-        title = "Related rates",
-        description = "Calculus with Julia: Related rates",
-        tags = ["CalculusWithJulia", "derivatives", "related rates"],
-);
-nothing
-```
 
 ---
 
@@ -814,4 +801,3 @@ choices = [
 answ=1
 radioq(choices, answ)
 ```
-

--- a/quarto/derivatives/taylor_series_polynomials.qmd
+++ b/quarto/derivatives/taylor_series_polynomials.qmd
@@ -16,15 +16,7 @@ using Unitful
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using Roots
-
-fig_size = (800, 600)
-const frontmatter = (
-        title = "Taylor Polynomials and other Approximating Polynomials",
-        description = "Calculus with Julia: Taylor Polynomials and other Approximating Polynomials",
-        tags = ["CalculusWithJulia", "derivatives", "taylor polynomials and other approximating polynomials"],
-);
 nothing
 ```
 
@@ -1259,5 +1251,3 @@ scatter!(cps, h1.(cps), markersize=5, marker=:square)
 ```
 
 Again by Rolle's theorem, between any pair of adjacent zeros $\xi^1_i, \xi^1_{i+1}$ there must be a zero $\xi^2_i$ of $h''(x)$. So there are $n-1$ zeros of $h''(x)$. Continuing, we see that there will be $n+1-3$ zeros of $h^{(3)}(x)$, $n+1-4$ zeros of $h^{4}(x)$, $\dots$, $n+1-(n-1)$ zeros of $h^{n-1}(x)$, and finally $n+1-n$ ($1$) zeros of $h^{(n)}(x)$. Call this last zero $\xi$. It satisfies $x_0 \leq \xi \leq x_n$. Further, $0 = h^{(n)}(\xi) = f^{(n)}(\xi)  - g^{(n)}(\xi)$. But $g$ is a degree $n$ polynomial, so the $n$th derivative is the coefficient of $x^n$ times $n!$. In this case we have $0 = f^{(n)}(\xi) - f[x_0, \dots, x_n] n!$. Rearranging yields the result.
-
-

--- a/quarto/differentiable_vector_calculus/plots_plotting.qmd
+++ b/quarto/differentiable_vector_calculus/plots_plotting.qmd
@@ -14,17 +14,6 @@ using LinearAlgebra
 using ForwardDiff
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-frontmatter = (
-    title = "2D and 3D plots in Julia with Plots",
-    description = "Calculus with Julia: 2D and 3D plots in Julia with Plots",
-    tags = ["CalculusWithJulia", "differentiable_vector_calculus", "2d and 3d plots in julia with plots"],
-);
-nothing
-```
 
 ---
 
@@ -121,10 +110,10 @@ for t in ts
 end
 ```
 
-```{julia}
-#| echo: false
-note("""Adding many arrows this way would be inefficient.""")
-```
+:::{.callout-note}
+## Note
+Adding many arrows this way would be inefficient.
+:::
 
 ### Setting a viewing angle for 3D plots
 
@@ -381,10 +370,10 @@ zs = [Z(1, theta, phi) for theta in thetas, phi in phis]
 surface(xs, ys, zs)
 ```
 
-```{julia}
-#| echo: false
-note("The above may not work with all backends for `Plots`, even if those that support 3D graphics.")
-```
+:::{.callout-note}
+## Note
+The above may not work with all backends for `Plots`, even if those that support 3D graphics.
+    :::
 
 For convenience, the `plot_parametric` function from `CalculusWithJulia` can produce these plots using interval notation, `a..b`,  and a function:
 
@@ -419,4 +408,3 @@ a,b = 1,3
 f(x,y,z) = (x^2+((1+b)*y)^2+z^2-1)^3-x^2*z^3-a*y^2*z^3
 CalculusWithJulia.plot_implicit_surface(f, xlim=-2..2, ylim=-1..1, zlim=-1..2)
 ```
-

--- a/quarto/differentiable_vector_calculus/polar_coordinates.qmd
+++ b/quarto/differentiable_vector_calculus/polar_coordinates.qmd
@@ -14,21 +14,6 @@ using Roots
 using QuadGK
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-frontmatter = (
-        title = "Polar Coordinates and Curves",
-        description = "Calculus with Julia: Polar Coordinates and Curves",
-        tags = ["CalculusWithJulia", "differentiable_vector_calculus", "polar coordinates and curves"],
-);
-using LaTeXStrings
-
-nothing
-```
-
 ---
 
 
@@ -785,4 +770,3 @@ r(theta) = sqrt(cos(2theta) * sec(theta)^4)
 val, _ = quadgk(t -> sqrt(D(r)(t)^2 + r(t)^2), -pi/4, pi/4)
 numericq(val)
 ```
-

--- a/quarto/differentiable_vector_calculus/scalar_functions.qmd
+++ b/quarto/differentiable_vector_calculus/scalar_functions.qmd
@@ -26,15 +26,7 @@ import Contour: contours, levels, level, lines, coordinates
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using CSV, DataFrames
-
-const frontmatter = (
-        title = "Scalar functions",
-        description = "Calculus with Julia: Scalar functions",
-        tags = ["CalculusWithJulia", "differentiable_vector_calculus", "scalar functions"],
-);
-
 nothing
 ```
 
@@ -2436,4 +2428,3 @@ What equation does the function $f(x,y) = \cos(x) + \sin(y)$ satisfy?
 answ = 5
 radioq(ode_choices, answ, keep_order=true)
 ```
-

--- a/quarto/differentiable_vector_calculus/scalar_functions_applications.qmd
+++ b/quarto/differentiable_vector_calculus/scalar_functions_applications.qmd
@@ -20,19 +20,6 @@ And the following from the `Contour` package:
 import Contour: contours, levels, level, lines, coordinates
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Applications with scalar functions",
-        description = "Calculus with Julia: Applications with scalar functions",
-        tags = ["CalculusWithJulia", "differentiable_vector_calculus", "applications with scalar functions"],
-);
-
-nothing
-```
 
 This section presents different applications of scalar functions.
 
@@ -2309,4 +2296,3 @@ ts = fzeros(fn, 0, 2pi)
 val = maximum((f∘r).(ts))
 numericq(val)
 ```
-

--- a/quarto/differentiable_vector_calculus/vector_fields.qmd
+++ b/quarto/differentiable_vector_calculus/vector_fields.qmd
@@ -14,19 +14,6 @@ using ForwardDiff
 using LinearAlgebra
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Functions ``R^n \\rightarrow R^m``",
-        description = "Calculus with Julia: Functions ``R^n \\rightarrow R^m``",
-        tags = ["CalculusWithJulia", "differentiable_vector_calculus", "functions ``R^n \\rightarrow R^m``"],
-);
-
-nothing
-```
 
 For a scalar function $f: R^n \rightarrow R$, the gradient of $f$, $\nabla{f}$, is a function from $R^n \rightarrow R^n$. Specializing to $n=2$, a function that for each point, $(x,y)$, assigns a vector $\vec{v}$. This is an example of vector field. More generally, we  could have a [function](https://en.wikipedia.org/wiki/Multivariable_calculus) $f: R^n \rightarrow R^m$, of which we have discussed many already:
 
@@ -1123,5 +1110,3 @@ radioq(choices, answ)
 ```
 
 (The latter is of interest, as only when the expression is $0$ will the vector field be the gradient of a scalar function.)
-
-

--- a/quarto/differentiable_vector_calculus/vector_valued_functions.qmd
+++ b/quarto/differentiable_vector_calculus/vector_valued_functions.qmd
@@ -23,18 +23,6 @@ import DifferentialEquations
 import DifferentialEquations: ODEProblem, Tsit5
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-frontmatter = (
-    title = "Vector-valued functions, ``f:R \\rightarrow R^n``",
-    description = "Calculus with Julia: Vector-valued functions, ``f:R \\rightarrow R^n``",
-    tags = ["CalculusWithJulia", "differentiable_vector_calculus", "vector-valued functions, ``f:R \\rightarrow r^n``"],
-);
-
-nothing
-```
 
 ---
 
@@ -2795,4 +2783,3 @@ choices = [
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/differentiable_vector_calculus/vectors.qmd
+++ b/quarto/differentiable_vector_calculus/vectors.qmd
@@ -13,19 +13,6 @@ using LinearAlgebra
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Vectors and matrices",
-        description = "Calculus with Julia: Vectors and matrices",
-        tags = ["CalculusWithJulia", "differentiable_vector_calculus", "vectors and matrices"],
-);
-
-nothing
-```
 
 ---
 
@@ -716,13 +703,10 @@ and
 ```{julia}
 [𝓊'; 𝓋']
 ```
-
-```{julia}
-#| echo: false
-note("""
+:::{.callout-note}
+## Note
 The adjoint is defined *recursively* in `Julia`. In the `CalculusWithJulia` package, we overload the `'` notation for *functions* to yield a univariate derivative found with automatic differentiation. This can lead to problems: if we have a matrix of functions, `M`, and took the transpose with `M'`, then the entries of `M'` would be the derivatives of the functions in `M` - not the original functions. This is very much likely to not be what is desired. The `CalculusWithJulia` package commits **type piracy** here *and* abuses the generic idea for `'` in Julia. In general type piracy is very much frowned upon, as it can change expected behaviour. It is defined in `CalculusWithJulia`, as that package is intended only to act as a means to ease users into the wider package ecosystem of `Julia`.
-""")
-```
+:::
 
 ---
 
@@ -768,12 +752,11 @@ $$
 \vec{u} \times \vec{v} =  \| \vec{u} \| \| \vec{v} \| \sin(\theta) \hat{n}.
 $$
 
-```{julia}
-#| echo: false
-note("""
+:::{callout-note}
+## Note
 The right-hand rule is also useful to understand how standard household screws will behave when twisted with a screwdriver. If the right hand fingers curl in the direction of the twisting screwdriver, then the screw will go in or out following the direction pointed to by the thumb.
-""")
-```
+
+:::
 
 The right-hand rule depends on the order of consideration of the vectors. If they are reversed, the opposite direction is determined. A consequence is that the cross product is **anti**-commutative, unlike multiplication:
 
@@ -1519,4 +1502,3 @@ choices = [
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/integral_vector_calculus/div_grad_curl.qmd
+++ b/quarto/integral_vector_calculus/div_grad_curl.qmd
@@ -15,13 +15,6 @@ using SymPy
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-const frontmatter = (
-        title = "The Gradient, Divergence, and Curl",
-        description = "Calculus with Julia: The Gradient, Divergence, and Curl",
-        tags = ["CalculusWithJulia", "integral_vector_calculus", "the gradient, divergence, and curl"],
-);
-nothing
 
 ## used in other blocks
 _bar(x) = sum(x)/length(x)
@@ -1676,4 +1669,3 @@ raw" ``rh'(r)e_\phi``"
 answ=1
 radioq(choices, answ)
 ```
-

--- a/quarto/integral_vector_calculus/double_triple_integrals.qmd
+++ b/quarto/integral_vector_calculus/double_triple_integrals.qmd
@@ -14,23 +14,6 @@ using SymPy
 using HCubature
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-#import PyPlot
-#pyplot()
-
-
-const frontmatter = (
-        title = "Multi-dimensional integrals",
-        description = "Calculus with Julia: Multi-dimensional integrals",
-        tags = ["CalculusWithJulia", "integral_vector_calculus", "multi-dimensional integrals"],
-);
-nothing
-```
-
 ---
 
 
@@ -1982,4 +1965,3 @@ raw" ``m\sqrt{1-m^2}dt^2+(1-2m^2)dtdv -m\sqrt{1-m^2}dv^2``"
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/integral_vector_calculus/line_integrals.qmd
+++ b/quarto/integral_vector_calculus/line_integrals.qmd
@@ -14,18 +14,6 @@ using SymPy
 using HCubature
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Line and Surface Integrals",
-        description = "Calculus with Julia: Line and Surface Integrals",
-        tags = ["CalculusWithJulia", "integral_vector_calculus", "line and surface integrals"],
-);
-nothing
-```
 
 ---
 
@@ -1504,4 +1492,3 @@ raw" ``1/60``"
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/integral_vector_calculus/review.qmd
+++ b/quarto/integral_vector_calculus/review.qmd
@@ -7,15 +7,7 @@
 #| echo: false
 #| results: "hidden"
 using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
 using Plots
-
-const frontmatter = (
-        title = "Quick Review of Vector Calculus",
-        description = "Calculus with Julia: Quick Review of Vector Calculus",
-        tags = ["CalculusWithJulia", "integral_vector_calculus", "quick review of vector calculus"],
-);
-
 nothing
 ```
 
@@ -486,5 +478,3 @@ The divergence theorem is available for other dimensions. In the $n=2$ case, it 
 
 
 The divergence theorem is used in Physics to express physical laws in either integral or differential form.
-
-

--- a/quarto/integral_vector_calculus/stokes_theorem.qmd
+++ b/quarto/integral_vector_calculus/stokes_theorem.qmd
@@ -16,12 +16,6 @@ using SymPy
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-const frontmatter = (
-        title = "Green's Theorem, Stokes' Theorem, and the Divergence Theorem",
-        description = "Calculus with Julia: Green's Theorem, Stokes' Theorem, and the Divergence Theorem",
-        tags = ["CalculusWithJulia", "integral_vector_calculus", "green's theorem, stokes' theorem, and the divergence theorem"],
-);
 
 # some useful helpers for drawing
 _bar(x) = sum(x)/length(x)
@@ -1593,4 +1587,3 @@ choices = [
 answ = 1
 radioq(choices, answ, keep_order=true)
 ```
-

--- a/quarto/integrals/arc_length.qmd
+++ b/quarto/integrals/arc_length.qmd
@@ -14,21 +14,6 @@ using QuadGK
 using Roots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-frontmatter = (
-    title = "Arc length",
-    description = "Calculus with Julia: Arc length",
-    tags = ["CalculusWithJulia", "integrals", "arc length"],
-);
-fig_size=(800, 600)
-
-nothing
-```
-
 ---
 
 
@@ -1071,4 +1056,3 @@ In [Martin](https://www.maa.org/sites/default/files/pdf/cmj_ftp/CMJ/January%2020
 After demonstrating mathematical talent at an early age, Blaise Pascal turned his attention to theology, denouncing the study of mathematics as a vainglorious pursuit. Then one night, unable to sleep as the result of a toothache, he began thinking about the cycloid and to his surprise, his tooth stopped aching. Taking this as a sign that he had God’s approval to continue, Pascal spent the next eight days studying the curve.  During this time he discovered nearly all of the geometric properties of the cycloid. He issued some of his results in $1658$ in the form of a contest, offering a prize of forty Spanish gold pieces and a second prize of twenty pieces.
 
 :::
-

--- a/quarto/integrals/area.qmd
+++ b/quarto/integrals/area.qmd
@@ -13,24 +13,6 @@ using QuadGK
 using Roots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-
-using CalculusWithJulia.WeaveSupport
-
-fig_size = (800, 600)
-using Markdown, Mustache
-
-const frontmatter = (
-        title = "Area under a curve",
-        description = "Calculus with Julia: Area under a curve",
-        tags = ["CalculusWithJulia", "integrals", "area under a curve"],
-);
-
-nothing
-```
-
 ---
 
 
@@ -1406,20 +1388,6 @@ numericq(val)
 ###### Question
 
 
-```{julia}
-#| hold: true
-#| echo: false
-caption = """
-The area under a curve approximated by a Riemann sum.
-"""
-#CalculusWithJulia.WeaveSupport.JSXGraph(joinpath(@__DIR__, "riemann.js"), caption)
-# url = "riemann.js"
-#CalculusWithJulia.WeaveSupport.JSXGraph(:integrals, url, caption)
-# This is just wrong...
-#CalculusWithJulia.WeaveSupport.JSXGraph(url, caption)
-nothing
-```
-
 ```{=html}
 <div id="jsxgraph" style="width: 500px; height: 500px;"></div>
 ```
@@ -1550,4 +1518,3 @@ f(x) = exp(x)
 val = sum([f(wi)*ni for (wi, ni) in zip(wts, ns)])
 numericq(val)
 ```
-

--- a/quarto/integrals/area_between_curves.qmd
+++ b/quarto/integrals/area_between_curves.qmd
@@ -14,18 +14,6 @@ using QuadGK
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Area between two curves",
-        description = "Calculus with Julia: Area between two curves",
-        tags = ["CalculusWithJulia", "integrals", "area between two curves"],
-);
-nothing
-```
 
 ---
 
@@ -752,4 +740,3 @@ Roberval, avoiding a trignometric integral, instead used symmetry to show that t
 """
 ImageFile(:integrals, imgfile, caption)
 ```
-

--- a/quarto/integrals/center_of_mass.qmd
+++ b/quarto/integrals/center_of_mass.qmd
@@ -15,18 +15,6 @@ using SymPy
 
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Center of Mass",
-        description = "Calculus with Julia: Center of Mass",
-        tags = ["CalculusWithJulia", "integrals", "center of mass"],
-);
-nothing
-```
 
 ---
 
@@ -640,4 +628,3 @@ xs = rs[4] .- rs
 val = sum(ms .* xs) / sum(ms)
 numericq(val)
 ```
-

--- a/quarto/integrals/ftc.qmd
+++ b/quarto/integrals/ftc.qmd
@@ -14,19 +14,6 @@ using Roots
 using QuadGK
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Fundamental Theorem or Calculus",
-        description = "Calculus with Julia: Fundamental Theorem or Calculus",
-        tags = ["CalculusWithJulia", "integrals", "fundamental theorem or calculus"],
-);
-fig_size = (800, 600)
-nothing
-```
 
 ---
 
@@ -1284,5 +1271,3 @@ Finding the value of a definite integral through the fundamental theorem of calc
 
 
   * This is a heuristic version of the Risch algorithm, meaning that        it is not deterministic.  This is tried as a last resort because        it can be very slow.  It is still used because not enough of the        full Risch algorithm is implemented, so that there are still some        integrals that can only be computed using this method.  The goal        is to implement enough of the Risch and Meijer G-function methods        so that this can be deleted.        Setting `heurisch=true` will cause `integrate` to use only this        method. Set `heurisch=false`  to not use it.
-
-

--- a/quarto/integrals/improper_integrals.qmd
+++ b/quarto/integrals/improper_integrals.qmd
@@ -13,20 +13,6 @@ using SymPy
 using QuadGK
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Improper Integrals",
-        description = "Calculus with Julia: Improper Integrals",
-        tags = ["CalculusWithJulia", "integrals", "improper integrals"],
-);
-fig_size=(800, 600)
-
-nothing
-```
 
 ---
 
@@ -587,4 +573,3 @@ a, b= 0, 1
 val, _ = quadgk(f, a, b)
 numericq(val)
 ```
-

--- a/quarto/integrals/integration_by_parts.qmd
+++ b/quarto/integrals/integration_by_parts.qmd
@@ -15,15 +15,7 @@ using SymPy
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using QuadGK
-
-frontmatter = (
-    title = "Integration By Parts",
-    description = "Calculus with Julia: Integration By Parts",
-    tags = ["CalculusWithJulia", "integrals", "integration by parts"],
-);
-
 nothing
 ```
 
@@ -703,4 +695,3 @@ choices = [
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/integrals/mean_value_theorem.qmd
+++ b/quarto/integrals/mean_value_theorem.qmd
@@ -12,18 +12,6 @@ using Plots
 using QuadGK
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Mean value theorem for integrals",
-        description = "Calculus with Julia: Mean value theorem for integrals",
-        tags = ["CalculusWithJulia", "integrals", "mean value theorem for integrals"],
-);
-nothing
-```
 
 ---
 
@@ -391,4 +379,3 @@ L"The exponential of the average of $\log(f)$"
 answ = val1 > val2 ? 1 : 2
 radioq(choices, answ)
 ```
-

--- a/quarto/integrals/partial_fractions.qmd
+++ b/quarto/integrals/partial_fractions.qmd
@@ -8,19 +8,6 @@ using CalculusWithJulia
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Partial Fractions",
-        description = "Calculus with Julia: Partial Fractions",
-        tags = ["CalculusWithJulia", "integrals", "partial fractions"],
-);
-nothing
-```
-
 ---
 
 
@@ -537,4 +524,3 @@ choices = ["``-2b\\arctan((x - \\alpha)/(\\beta))``",
            "``2b\\sec^2(-(x-\\alpha)/(-\\beta))``"]
 radioq(choices, 1)
 ```
-

--- a/quarto/integrals/substitution.qmd
+++ b/quarto/integrals/substitution.qmd
@@ -13,18 +13,6 @@ using SymPy
 
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Substitution",
-        description = "Calculus with Julia: Substitution",
-        tags = ["CalculusWithJulia", "integrals", "substitution"],
-);
-nothing
-```
 
 ---
 
@@ -864,4 +852,3 @@ L"We could differentiate $\log\lvert (\sec(u) + \tan(u))\rvert$ "]
 answ = 2
 radioq(choices, answ)
 ```
-

--- a/quarto/integrals/surface_area.qmd
+++ b/quarto/integrals/surface_area.qmd
@@ -13,20 +13,6 @@ using SymPy
 using QuadGK
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Surface Area",
-        description = "Calculus with Julia: Surface Area",
-        tags = ["CalculusWithJulia", "integrals", "surface area"],
-);
-fig_size=(800, 600)
-nothing
-```
-
 ---
 
 
@@ -585,4 +571,3 @@ a, b = 0, pi
 val, _ = quadgk(t -> 2pi* f(t) * sqrt(g'(t)^2 + f'(t)^2), a, b)
 numericq(val)
 ```
-

--- a/quarto/integrals/volumes_slice.qmd
+++ b/quarto/integrals/volumes_slice.qmd
@@ -18,15 +18,7 @@ using SymPy
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
 import LinearAlgebra: norm
-
-const frontmatter = (
-        title = "Volumes by slicing",
-        description = "Calculus with Julia: Volumes by slicing",
-        tags = ["CalculusWithJulia", "integrals", "volumes by slicing"],
-);
 nothing
 ```
 
@@ -848,4 +840,3 @@ rad(u) = sqrt((u*cos(theta) - xval(u))^2 + (u*sin(theta) - f(xval(u)))^2)
 val, _ = quadgk(u -> pi*rad(u)^2, a, b)
 numericq(val)
 ```
-

--- a/quarto/limits/continuity.qmd
+++ b/quarto/limits/continuity.qmd
@@ -12,19 +12,6 @@ using Plots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Continuity",
-        description = "Calculus with Julia: Continuity",
-        tags = ["CalculusWithJulia", "limits", "continuity"],
-);
-
-nothing
-```
 
 ---
 
@@ -508,4 +495,3 @@ choices = ["Can't tell",
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/limits/intermediate_value_theorem.qmd
+++ b/quarto/limits/intermediate_value_theorem.qmd
@@ -13,21 +13,6 @@ using Roots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Implications of continuity",
-        description = "Calculus with Julia: Implications of continuity",
-        tags = ["CalculusWithJulia", "limits", "implications of continuity"],
-);
-
-fig_size=(800, 600)
-nothing
-```
-
 ---
 
 
@@ -1114,4 +1099,3 @@ a,b = 1, 2
 k_x, k_y = 3, 4
 plot(t -> a * cos(k_x *t), t-> b * sin(k_y * t), 0, 4pi)
 ```
-

--- a/quarto/limits/limits.qmd
+++ b/quarto/limits/limits.qmd
@@ -13,19 +13,6 @@ using Richardson  # for extrapolation
 using SymPy       # for symbolic limits
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Limits",
-        description = "Calculus with Julia: Limits",
-        tags = ["CalculusWithJulia", "limits", "limits"],
-);
-fig_size=(800, 600)
-nothing
-```
 
 ---
 
@@ -1705,5 +1692,3 @@ yesnoq("yes")
 ```
 
 (If so, then the squeeze theorem would say that $\pi$ is the common limit.)
-
-

--- a/quarto/limits/limits_extensions.qmd
+++ b/quarto/limits/limits_extensions.qmd
@@ -15,14 +15,7 @@ using SymPy
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using DataFrames
-
-const frontmatter = (
-        title = "Limits, issues, extensions of the concept",
-        description = "Calculus with Julia: Limits, issues, extensions of the concept",
-        tags = ["CalculusWithJulia", "limits", "limits, issues, extensions of the concept"],
-);
 nothing
 ```
 
@@ -148,6 +141,7 @@ There are other such functions that jump. Another useful one is the floor functi
 ```{julia}
 plot(floor, -5,5)
 ```
+
 
 Again, the (nearly) vertical lines are an artifact of the graphing algorithm and not actual points that solve $y=f(x)$. The floor function has limits except at the integers. There the left and right limits differ.
 
@@ -1041,4 +1035,3 @@ L" $f(x)$ does not have a limit as $x \rightarrow 0$"
 answ = 3
 radioq(choices, answ)
 ```
-

--- a/quarto/misc/quick_notes.qmd
+++ b/quarto/misc/quick_notes.qmd
@@ -447,15 +447,15 @@ Row and column vectors can fill in:
 
 ```{julia}
 ys = [4 5] # a row vector
-h(x,y) = (x,y)
-h.(xs, ys)    # broadcasting a column and row vector makes a matrix, then applies f.
+g(x,y) = (x,y)
+g.(xs, ys)    # broadcasting a column and row vector makes a matrix, then applies f.
 ```
 
 This should be contrasted to the case when both `xs` and `ys` are (column) vectors, as then they pair off (and here cause a dimension mismatch as they have different lengths):
 
 
 ```{julia}
-h.(xs, [4,5])
+g.(xs, [4,5])
 ```
 
   * The `map` function is similar, it applies a function to each element:
@@ -1075,9 +1075,9 @@ For symbolic expressions, we have the `∇ ×` times notation is available **if*
 ```{julia}
 #| hold: true
 @syms x y z
-F = [-y, x, z]  #  but not [-y, x, 1] which errs; use `curl` with variables specified
+𝑭 = [-y, x, z]  #  but not [-y, x, 1] which errs; use `curl` with variables specified
 
-curl([-y, x, 1], (x,y,z)),  ∇×F
+curl([-y, x, 1], (x,y,z)),  ∇×𝑭
 ```
 
 ## Integrals

--- a/quarto/precalc/calculator.qmd
+++ b/quarto/precalc/calculator.qmd
@@ -6,14 +6,6 @@
 ```{julia}
 #| echo: false
 using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
-
-frontmatter = (
-        title = "From calculator to computer",
-        description = "Calculus with Julia: Replacing the calculator with a computer",
-        tags = ["CalculusWithJulia", "precalc", "replacing the calculator with a computer"],
-);
-
 nothing
 ```
 
@@ -25,6 +17,7 @@ The following image is the calculator that Google presents upon searching for "c
 
 ```{julia}
 #| echo: false
+#
 imgfile = "figures/calculator.png"
 caption = "Screenshot of a calculator provided by the Google search engine."
 ImageFile(:precalc, imgfile, caption)
@@ -50,7 +43,7 @@ txt = """
 </iframe>
 </center>
 """
-CalculusWithJulia.WeaveSupport.HTMLoutput(txt)
+HTMLoutput(txt)
 ```
 
 ## Operations
@@ -90,23 +83,19 @@ An expression like $6 - -3$, subtracting minus three from six, must be handled w
 6 - -3
 ```
 
-(If no space is included, the value "`--`" is parsed like a different, undefined, operation.)
+(If no space is included, the value "`--`" is parsed like a different, invalid, operation.)
 
-
-```{julia}
-#| echo: false
-warning(L"""
-
+:::{.callout-warning}
+## Warning
 `Julia` only uses one symbol for minus, but web pages may not! Copying
 and pasting an expression with a minus sign can lead to hard to
 understand errors such as: `invalid character "−"`. There are several
-Unicode symbols that look similar to the ASCII minus sign, but are
+Unicode symbols that look similar to the ASCII minus sign, though
 different. These notes use a different character for the minus sign for
 the typeset math (e.g., $1 - \pi$) than for the code within cells
 (e.g. `1 - 2`). Thus, copying and pasting the typeset math may not work as expected.
+:::
 
-""")
-```
 
 ### Examples
 
@@ -369,14 +358,14 @@ In most cases. There are occasional (basically rare) spots where using `pi` by i
 ### Numeric literals
 
 
-For some special cases, Julia implements *multiplication* without a multiplication symbol. This is when the value on the left is a number, as in `2pi`, which has an equivalent value to `2*pi`. *However* the two are not equivalent, in that multiplication with *numeric literals* does not have the same precedence as regular multiplication - it is higher. This has practical importance when used in division or powers. For instance, these two are **not** the same:
+For some special cases, Julia parses *multiplication* without a multiplication symbol. This is when the value on the left is a number, as in `2pi`, which has an equivalent value to `2*pi`. *However* the two are not equivalent, in that multiplication with *numeric literals* does not have the same precedence as regular multiplication - it is higher. This has practical importance when used in division or powers. For instance, these two are **not** the same:
 
 
 ```{julia}
 1/2pi, 1/2*pi
 ```
 
-Why? Because the first `2pi` is performed before division, as multiplication with numeric literals  has higher precedence than regular multiplication, which is at the same level as division.
+Why? Because the first `2pi` is performed before division, as multiplication with numeric literals has higher precedence than regular multiplication, which is at the same level as division.
 
 
 To confuse things even more, consider
@@ -436,7 +425,8 @@ julia = [
 "`factorial`"
 ]
 
-CalculusWithJulia.WeaveSupport.table(DataFrame(Calculator=calc, Julia=julia))
+d = DataFrame(Calculator=calc, Julia=julia)
+Table(d)
 ```
 
 Using a function is very straightforward. A function is called using parentheses, in a manner visually similar to how a function is called mathematically. So if we consider the `sqrt` function, we have:
@@ -1068,4 +1058,3 @@ choices = [
 answ=1
 radioq(choices, answ)
 ```
-

--- a/quarto/precalc/exp_log_functions.qmd
+++ b/quarto/precalc/exp_log_functions.qmd
@@ -11,19 +11,6 @@ using CalculusWithJulia
 using Plots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-	title = "Exponential and logarithmic functions",
-	description = "Calculus with julia",
-	tags = ["CalculusWithJulia", "precalc", "exponential and logarithmic functions"],
-);
-
-nothing
-```
 
 ---
 
@@ -692,4 +679,3 @@ L"as $a^x   < 1$, $a^y < a^x$",
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/precalc/functions.qmd
+++ b/quarto/precalc/functions.qmd
@@ -10,19 +10,6 @@ This section will use the following add-on packages:
 using CalculusWithJulia, Plots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Functions",
-        description = "Calculus with Julia: Functions",
-        tags = ["CalculusWithJulia", "precalc", "functions"],
-);
-
-nothing
-```
 
 ---
 

--- a/quarto/precalc/inversefunctions.qmd
+++ b/quarto/precalc/inversefunctions.qmd
@@ -11,20 +11,6 @@ using CalculusWithJulia
 using Plots
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "The Inverse of a Function",
-        description = "Calculus with Julia: The Inverse of a Function",
-        tags = ["CalculusWithJulia", "precalc", "the inverse of a function"],
-);
-
-nothing
-```
-
 ---
 
 
@@ -775,4 +761,3 @@ What about the value of $g_1(g_2(g_3(g_4(f_4(f_3(f_2(f_1(10))))))))$?
 val = g1(g2(g3(g4(f4(f3(f2(f1(10))))))))
 numericq(val)
 ```
-

--- a/quarto/precalc/julia_overview.qmd
+++ b/quarto/precalc/julia_overview.qmd
@@ -7,12 +7,6 @@
 #| echo: false
 #| results: "hidden"
 using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
-const frontmatter = (
-        title = "Overview of Julia commands",
-        description = "Calculus with Julia: Overview of Julia commands",
-        tags = ["CalculusWithJulia", "precalc", "overview of julia commands"],
-);
 
 nothing
 ```

--- a/quarto/precalc/logical_expressions.qmd
+++ b/quarto/precalc/logical_expressions.qmd
@@ -13,14 +13,7 @@ using CalculusWithJulia    # loads the `SpecialFunctions` package
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using Plots
-
-const frontmatter = (
-        title = "Inequalities, Logical expressions",
-        description = "Calculus with Julia: Inequalities, Logical expressions",
-        tags = ["CalculusWithJulia", "precalc", "inequalities, logical expressions"],
-);
 nothing
 ```
 

--- a/quarto/precalc/numbers_types.qmd
+++ b/quarto/precalc/numbers_types.qmd
@@ -7,12 +7,6 @@
 #| echo: false
 #| results: "hidden"
 using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
-const frontmatter = (
-        title = "Number systems",
-        description = "Calculus with Julia: Number systems",
-        tags = ["CalculusWithJulia", "precalc", "number systems"],
-);
 
 nothing
 ```
@@ -630,5 +624,3 @@ yesnoq(false)
 ```
 
 (This shows the special casing that is done when powers use literal numbers.)
-
-

--- a/quarto/precalc/plotting.qmd
+++ b/quarto/precalc/plotting.qmd
@@ -14,16 +14,9 @@ using Plots
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using Roots
 using SymPy
 using DataFrames
-
-const frontmatter = (
-        title = "The Graph of a Function",
-        description = "Calculus with Julia: The Graph of a Function",
-        tags = ["CalculusWithJulia", "precalc", "the graph of a function"],
-);
 
 nothing
 ```
@@ -957,5 +950,3 @@ The slow "time to first plot" in `Julia` is a well-known hiccup that is related 
 
 
 `Julia` is an interactive language that attains its speed by compiling functions on the fly using the [llvm](llvm.org) compiler. When `Julia` encounters a new combination of a function method and argument types it will compile and cache a function for subsequent speedy execution. The first plot is slow, as there are many internal functions that get compiled. This has sped up of late, as excessive recompilations have been trimmed down, but still has a way to go. This is different from "precompilation" which also helps trim down time for initial executions. There are also some more technically challenging means to create `Julia` images for faster start up that can be pursued if needed.
-
-

--- a/quarto/precalc/polynomial.qmd
+++ b/quarto/precalc/polynomial.qmd
@@ -15,15 +15,6 @@ using Plots
 #| echo: false
 #| results: "hidden"
 using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
-
-fig_size = (800, 600) #400, 300)
-
-const frontmatter = (
-        title = "Polynomials",
-        description = "Calculus with Julia: Polynomials",
-        tags = ["CalculusWithJulia", "precalc", "polynomials"],
-);
 nothing
 ```
 
@@ -835,4 +826,3 @@ q"0"]
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/precalc/polynomial_roots.qmd
+++ b/quarto/precalc/polynomial_roots.qmd
@@ -15,15 +15,8 @@ using SymPy
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using Roots
 import LinearAlgebra: norm
-
-const frontmatter = (
-        title = "Roots of a polynomial",
-        description = "Calculus with Julia: Roots of a polynomial",
-        tags = ["CalculusWithJulia", "precalc", "roots of a polynomial"],
-);
 
 nothing
 ```
@@ -1039,5 +1032,3 @@ If the bottom row represents $q_7, q_6, \dots, q_0$  and the top row $p_8, p_7, 
 
 
 As such, the `var(p)` $\geq 1 +$ `var(q)`.
-
-

--- a/quarto/precalc/polynomials_package.qmd
+++ b/quarto/precalc/polynomials_package.qmd
@@ -14,20 +14,6 @@ using RealPolynomialRoots
 import SymPy # imported only: some functions, e.g. degree, need qualification
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "The Polynomials package",
-        description = "Calculus with Julia: The Polynomials package",
-        tags = ["CalculusWithJulia", "precalc", "the polynomials package"],
-);
-
-nothing
-```
-
 ---
 
 
@@ -592,4 +578,3 @@ The `Polynomials` package has an implementation, so you can check your answer th
 The `ApproxFun` package is built on top of polynomials expressed in this basis, as the Chebyshev polynomials have special properties which make them very suitable when approximating functions with polynomials. The `ApproxFun` package uses  easier-to-manipulate polynomials to approximate functions very accurately, thereby being useful for investigating properties of non-linear functions leveraging properties for polynomials.
 
 :::
-

--- a/quarto/precalc/ranges.qmd
+++ b/quarto/precalc/ranges.qmd
@@ -3,19 +3,6 @@
 
 {{< include ../_common_code.qmd >}}
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
-frontmatter = (
-        title = "Ranges and Sets",
-        description = "Calculus with Julia: Ranges and Sets",
-        tags = ["CalculusWithJulia", "precalc", "ranges and sets"],
-);
-
-nothing
-```
 
 ## Arithmetic sequences
 

--- a/quarto/precalc/rational_functions.qmd
+++ b/quarto/precalc/rational_functions.qmd
@@ -17,21 +17,6 @@ using RealPolynomialRoots
 The `Polynomials` package is "imported" to avoid naming collisions with `SymPy`; names will need to be qualified.
 
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Rational functions",
-        description = "Calculus with Julia: Rational functions",
-        tags = ["CalculusWithJulia", "precalc", "rational functions"],
-);
-
-using Roots
-
-nothing
-```
 
 ---
 
@@ -426,41 +411,6 @@ The usual recipe for construction follows these steps:
 
 With the computer, where it is convenient to draw a graph, it might be better to emphasize the sign on the graph of the function. The `sign_chart` function from `CalculusWithJulia` does this by numerically identifying points where the function is $0$ or $\infty$ and indicating the sign as $x$ crosses over these points.
 
-
-```{julia}
-#| echo: false
-# in CalculusWithJuia
-function sign_chart(f, a, b; atol=1e-6)
-    pm(x) = x < 0 ? "-" : x > 0 ? "+" : "0"
-    summarize(f,cp,d) = (∞0=cp, sign_change=pm(f(cp-d)) * " → " * pm(f(cp+d)))
-
-    zs = find_zeros(f, a, b)
-    pts = vcat(a, zs, b)
-    for (u,v) ∈ zip(pts[1:end-1], pts[2:end])
-        zs′ = find_zeros(x -> 1/f(x), u, v)
-        for z′ ∈ zs′
-            flag = false
-            for z ∈ zs
-                if isapprox(z′, z, atol=atol)
-                    flag = true
-                    break
-                end
-            end
-            !flag && push!(zs, z′)
-        end
-    end
-    sort!(zs)
-
-    length(zs) == 0 && return []
-    m,M = extrema(zs)
-    d = min((m-a)/2, (b-M)/2)
-    if length(zs) > 0
-        d′ = minimum(diff(zs))/2
-        d = min(d, d′ )
-    end
-    summarize.(f, zs, d)
-end
-```
 
 ```{julia}
 #| hold: true
@@ -1046,4 +996,3 @@ L"The $\sin(x)$ oscillates, but the rational function has a horizontal asymptote
 answ = 2
 radioq(choices, answ)
 ```
-

--- a/quarto/precalc/transformations.qmd
+++ b/quarto/precalc/transformations.qmd
@@ -14,14 +14,7 @@ using Plots
 ```{julia}
 #| echo: false
 #| results: "hidden"
-using CalculusWithJulia.WeaveSupport
 using DataFrames
-
-const frontmatter = (
-        title = "Function manipulations",
-        description = "Calculus with Julia: Function manipulations",
-        tags = ["CalculusWithJulia", "precalc", "function manipulations"],
-);
 nothing
 ```
 

--- a/quarto/precalc/trig_functions.qmd
+++ b/quarto/precalc/trig_functions.qmd
@@ -12,22 +12,6 @@ using Plots
 using SymPy
 ```
 
-```{julia}
-#| echo: false
-#| results: "hidden"
-using CalculusWithJulia.WeaveSupport
-
-fig_size = (800, 600)
-
-const frontmatter = (
-        title = "Trigonometric functions",
-        description = "Calculus with Julia: Trigonometric functions",
-        tags = ["CalculusWithJulia", "precalc", "trigonometric functions"],
-);
-
-nothing
-```
-
 ---
 
 
@@ -378,9 +362,7 @@ As can be seen, even a somewhat simple combination can produce complicated graph
 txt ="""
 <iframe width="560" height="315" src="https://www.youtube.com/embed/rrmx2Q3sO1Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 """
-tpl = CalculusWithJulia.WeaveSupport.centered_content_tpl
-txt = CalculusWithJulia.WeaveSupport.Mustache.render(tpl, content=txt, caption="Julia logo animated")
-CalculusWithJulia.WeaveSupport.HTMLoutput(txt)
+HTMLoutput(txt; centered=true, caption="Julia logo animated")
 ```
 
 ### Functions using degrees
@@ -884,4 +866,3 @@ Is this identical to the pattern for the regular sine function?
 #| echo: false
 yesnoq(false)
 ```
-

--- a/quarto/precalc/variables.qmd
+++ b/quarto/precalc/variables.qmd
@@ -10,13 +10,6 @@
 #| echo: false
 #| results: "hidden"
 using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
-
-const frontmatter = (
-        title = "Variables",
-        description = "Calculus with Julia: Variables",
-        tags = ["CalculusWithJulia", "precalc", "variables"],
-);
 
 nothing
 ```
@@ -493,4 +486,3 @@ choices = ["Assign all three variables at once to a value of `3`",
 answ = 1
 radioq(choices, answ)
 ```
-

--- a/quarto/precalc/vectors.qmd
+++ b/quarto/precalc/vectors.qmd
@@ -8,19 +8,9 @@
 #| echo: false
 #| results: "hidden"
 using CalculusWithJulia
-using CalculusWithJulia.WeaveSupport
 using Plots
 using Measures
 using LaTeXStrings
-
-#fig_size = (400, 300)
-fig_size = (800, 600)
-
-const frontmatter = (
-        title = "Vectors",
-        description = "Calculus with Julia: Vectors",
-        tags = ["CalculusWithJulia", "precalc", "vectors"],
-);
 
 nothing
 ```
@@ -711,11 +701,11 @@ The style generally employed here is to use plural variable names for a collecti
 ## Other container types
 
 
-Vectors in `Julia` are a container, one of many different types. Another useful type for programming purposes are *tuples*. If a vector is formed by placing comma-separated values within a `[]` pair (e.g., `[1,2,3]`), a tuple is formed by placing comma-separated values withing a `()` pair. A tuple of length $1$ uses a convention of a trailing comma to distinguish it from a parenthesized expression (e.g. `(1,)` is a tuple, `(1)` is just the value `1`).
+Vectors in `Julia` are a container, one of many different types. Another useful type for programming purposes are *tuples*. If a vector is formed by placing comma-separated values within a `[]` pair (e.g., `[1,2,3]`), a tuple is formed by placing comma-separated values withing a `()` pair.  A tuple of length $1$ uses a convention of a trailing comma to distinguish it from a parenthesized expression (e.g. `(1,)` is a tuple, `(1)` is just the value `1`).
 
 :::{.callout-note}
 ## Well, actually...
-Technically, the tuple is formed by the use of commas, which separate different expressions. The parentheses are typically used, as they clarify the intent. In a notebook interface, it is useful to just use commas to separate values to output, as typically the only the last command is displayed. This usage just forms a tuple of the values and displays that.
+Technically, the tuple is formed just by the use of commas, which separate different expressions. The parentheses are typically used, as they clarify the intent and disambiguate some usage. In a notebook interface, it is useful to just use commas to separate values to output, as typically the only the last command is displayed. This usage just forms a tuple of the values and displays that.
 
 :::
 


### PR DESCRIPTION
* remove WeaveSupport use from CalculusWithJulia package, allowing the trimming down of that package to be for math functions only
* fix a few bugs
* deprecate idea that we can use CI infrastructure to generate these files, as they are too resource heavy and we end up with timeouts.