### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Read Notes](https://img.shields.io/badge/docs-latest-blue.svg)](https://jverzani.github.io/CalculusWithJuliaNotes.jl/)
 
 
-A collection of [notes]((https://jverzani.github.io/CalculusWithJuliaNotes.jl/)) related to using `Julia` in the study of Calculus.
+A collection of [notes](https://jverzani.github.io/CalculusWithJuliaNotes.jl/) related to using `Julia` in the study of Calculus.


### PR DESCRIPTION
The hyperlink has an extra set of parentheses, which is causing the markdown link syntax to be malformed.

The issue was an extra set of parentheses in the markdown link syntax. The link should now work properly and will direct users to the Calculus with Julia notes website.