### PR TITLE
Corrected Latex function in optimization example

### DIFF
--- a/quarto/derivatives/optimization.qmd
+++ b/quarto/derivatives/optimization.qmd
@@ -699,7 +699,7 @@ Here traveling directly to the point $(L,0)$ is fastest. Though travel is slower
 ## Unbounded domains
 
 
-Maximize the function $xe^{-(1/2) x^2}$ over the interval $[0, \infty)$.
+Maximize the function $xe^{-x^2}$ over the interval $[0, \infty)$.
 
 
 Here the extreme value theorem doesn't technically apply, as we don't have a closed interval. However, **if** we can eliminate the endpoints as candidates, then we should be able to convince ourselves the maximum must occur at a critical point of $f(x)$. (If not, then convince yourself for all sufficiently large $M$ the maximum over $[0,M]$ occurs at a critical point, not an endpoint. Then let $M$ go to infinity.


### PR DESCRIPTION
Thanks for the resource, I just noticed a typo in the latex code for one of the examples.